### PR TITLE
Add defaultUser to `wheel` group

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -21,6 +21,7 @@ in
 
   users.users.${defaultUser} = {
     isNormalUser = true;
+    extraGroups = [ "wheel" ];
   };
 
   users.users.root = {


### PR DESCRIPTION
Hi,

Without this change I'm locked out of the root user with the default configuration.nix unless I'm missing something. It seems `wsl.exe --user root` doesn't do anything, I'm still logged in as `defaultUser`.

Fixing this problem after the fact requires re-building the tarball and reinstalling the WSL distro. Let's remove one pitfall for new users :-)

Thanks!