### PR TITLE
Check format in workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,6 @@
 name: 'Build NixOS WSL tarball'
 
-on: push
+on: [push, pull_request]
 
 jobs:
   build:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,6 +20,10 @@ jobs:
           extra_nix_config: |
             experimental-features = nix-command flakes
 
+      - name: Run checks
+        run: |
+          nix flake check
+
       - name: Build tarball
         run: |
           nix build '.#nixosConfigurations.mysystem.config.system.build.tarball'

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 result
+result-*

--- a/build-tarball.nix
+++ b/build-tarball.nix
@@ -1,15 +1,14 @@
 { config, pkgs, lib, nixpkgs ? <nixpkgs>, ... }:
 
 with lib;
-
 let
-   pkgs2storeContents = l : map (x: { object = x; symlink = "none"; }) l;
+  pkgs2storeContents = l: map (x: { object = x; symlink = "none"; }) l;
 
-   nixpkgs = lib.cleanSource pkgs.path;
+  nixpkgs = lib.cleanSource pkgs.path;
 
-   channelSources = pkgs.runCommand "nixos-${config.system.nixos.version}"
-     { preferLocalBuild = true; }
-     ''
+  channelSources = pkgs.runCommand "nixos-${config.system.nixos.version}"
+    { preferLocalBuild = true; }
+    ''
       mkdir -p $out
       cp -prd ${nixpkgs.outPath} $out/nixos
       chmod -R u+w $out/nixos
@@ -21,43 +20,44 @@ let
       echo ${config.system.nixos.versionSuffix} | sed -e s/pre// > $out/nixos/svn-revision
     '';
 
-   preparer = pkgs.writeShellScriptBin "wsl-prepare" ''
-     set -e
+  preparer = pkgs.writeShellScriptBin "wsl-prepare" ''
+    set -e
 
-     mkdir -m 0755 ./bin ./etc
-     mkdir -m 1777 ./tmp
+    mkdir -m 0755 ./bin ./etc
+    mkdir -m 1777 ./tmp
 
-     # WSL requires a /bin/sh - only temporary, NixOS's activate will overwrite
-     ln -s ${pkgs.stdenv.shell} ./bin/sh
+    # WSL requires a /bin/sh - only temporary, NixOS's activate will overwrite
+    ln -s ${pkgs.stdenv.shell} ./bin/sh
 
-     # WSL also requires a /bin/mount, otherwise the host fs isn't accessible
-     ln -s /nix/var/nix/profiles/system/sw/bin/mount ./bin/mount
+    # WSL also requires a /bin/mount, otherwise the host fs isn't accessible
+    ln -s /nix/var/nix/profiles/system/sw/bin/mount ./bin/mount
 
-     # Set system profile
-     system=${config.system.build.toplevel}
-     ./$system/sw/bin/nix-store --store `pwd` --load-db < ./nix-path-registration
-     rm ./nix-path-registration
-     ./$system/sw/bin/nix-env --store `pwd` -p ./nix/var/nix/profiles/system --set $system
+    # Set system profile
+    system=${config.system.build.toplevel}
+    ./$system/sw/bin/nix-store --store `pwd` --load-db < ./nix-path-registration
+    rm ./nix-path-registration
+    ./$system/sw/bin/nix-env --store `pwd` -p ./nix/var/nix/profiles/system --set $system
 
-     # Set channel
-     mkdir -p ./nix/var/nix/profiles/per-user/root
-     ./$system/sw/bin/nix-env --store `pwd` -p ./nix/var/nix/profiles/per-user/root/channels --set ${channelSources}
-     mkdir -m 0700 -p ./root/.nix-defexpr
-     ln -s /nix/var/nix/profiles/per-user/root/channels ./root/.nix-defexpr/channels
+    # Set channel
+    mkdir -p ./nix/var/nix/profiles/per-user/root
+    ./$system/sw/bin/nix-env --store `pwd` -p ./nix/var/nix/profiles/per-user/root/channels --set ${channelSources}
+    mkdir -m 0700 -p ./root/.nix-defexpr
+    ln -s /nix/var/nix/profiles/per-user/root/channels ./root/.nix-defexpr/channels
 
-     # It's now a NixOS!
-     touch ./etc/NIXOS
+    # It's now a NixOS!
+    touch ./etc/NIXOS
 
-     # Copy the system configuration
-     mkdir -p ./etc/nixos
-     cp ${./configuration.nix} ./etc/nixos/configuration.nix
-     cp ${./syschdemd.nix} ./etc/nixos/syschdemd.nix
-     cp ${./syschdemd.sh} ./etc/nixos/syschdemd.sh
-   '';
+    # Copy the system configuration
+    mkdir -p ./etc/nixos
+    cp ${./configuration.nix} ./etc/nixos/configuration.nix
+    cp ${./syschdemd.nix} ./etc/nixos/syschdemd.nix
+    cp ${./syschdemd.sh} ./etc/nixos/syschdemd.sh
+  '';
 in
-{  system.build.tarball = pkgs.callPackage "${nixpkgs}/nixos/lib/make-system-tarball.nix" {
+{
+  system.build.tarball = pkgs.callPackage "${nixpkgs}/nixos/lib/make-system-tarball.nix" {
     # No contents, structure will be added by prepare script
-    contents = [];
+    contents = [ ];
 
     storeContents = pkgs2storeContents [
       config.system.build.toplevel

--- a/configuration.nix
+++ b/configuration.nix
@@ -1,7 +1,6 @@
 { lib, pkgs, config, modulesPath, ... }:
 
 with lib;
-
 let
   defaultUser = "nixos";
   syschdemd = import ./syschdemd.nix { inherit lib pkgs config defaultUser; };

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,20 @@
 {
   "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1610051610,
+        "narHash": "sha256-U9rPz/usA1/Aohhk7Cmc2gBrEEKRzcW4nwPWMPwja4Y=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "3982c9903e93927c2164caa727cd3f6a0e6d14cc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1610124236,
@@ -17,6 +32,7 @@
     },
     "root": {
       "inputs": {
+        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -1,22 +1,36 @@
-
 {
   description = "NixOS WSL";
 
- inputs = {
-    nixpkgs.url = "nixpkgs/nixos-20.09";
-  };
-  
-  outputs = { nixpkgs, ... }@inputs: {
-    nixosConfigurations = {
+  inputs.nixpkgs.url = "nixpkgs/nixos-20.09";
+  inputs.flake-utils.url = "github:numtide/flake-utils";
 
-      mysystem = inputs.nixpkgs.lib.nixosSystem {
+  outputs = { self, nixpkgs, flake-utils, ... }:
+    {
+      nixosConfigurations.mysystem = nixpkgs.lib.nixosSystem {
         system = "x86_64-linux";
         modules = [
           (import ./configuration.nix)
           (import ./build-tarball.nix)
         ];
-        specialArgs = { inherit (inputs) nixpkgs; };
+        specialArgs = { inherit nixpkgs; };
       };
-    };
-  };
+    } //
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+      in
+      {
+        checks.check-format = pkgs.runCommand "check-format"
+          {
+            buildInputs = with pkgs; [ nixpkgs-fmt ];
+          } ''
+          nixpkgs-fmt --check ${./.}
+          mkdir $out # success
+        '';
+
+        devShell = pkgs.mkShell {
+          nativeBuildInputs = with pkgs; [ nixpkgs-fmt ];
+        };
+      }
+    );
 }


### PR DESCRIPTION
- Add a check to `flake.nix` which asserts that Nix source files a properly formatted using `nixpkgs-fmt`. 
- Run the check as part of the workflow
- Also execute the workflow for PRs