### PR TITLE
Avoid having to run nix activate on first run

### DIFF
--- a/build-tarball.nix
+++ b/build-tarball.nix
@@ -27,7 +27,7 @@ let
     mkdir -m 1777 ./tmp
 
     # WSL requires a /bin/sh - only temporary, NixOS's activate will overwrite
-    ln -s ${pkgs.stdenv.shell} ./bin/sh
+    ln -s ${config.users.users.root.shell} ./bin/sh
 
     # WSL also requires a /bin/mount, otherwise the host fs isn't accessible
     ln -s /nix/var/nix/profiles/system/sw/bin/mount ./bin/mount

--- a/build-tarball.nix
+++ b/build-tarball.nix
@@ -61,7 +61,6 @@ in
 
     storeContents = pkgs2storeContents [
       config.system.build.toplevel
-      pkgs.stdenv
       channelSources
       preparer
     ];


### PR DESCRIPTION
This sets the initial /bin/sh to syschdemd, which means that the user no longer has to manually run nix activate.
Instead the user will be logged in to the default user account.

I've tested this with the `wsl.exe --import` install method but I haven't tested if it works with DistroLauncher.